### PR TITLE
Add option to clear the RStudio console before sending code

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ In your global configuration file (`~/.atom/init.coffee`), you may set the follo
 - `r-exec.focusWindow`
   - if `true`, focus the window before sending code
   - if `false`, send the code in the background and stay focused on Atom. This is not possible when sending code to a browser
+- `r-exec.clearRStudioConsole`
+  - if `true` and `whichApp` is set to `RStudio`, the RStudio console will be cleared before sending code
 - `r-exec.notifications`
   - if `true`, notifications via `NotificationManager` when a paragraph or function is not identified
 - `r-exec.smartInsertOperator`

--- a/lib/r-exec.coffee
+++ b/lib/r-exec.coffee
@@ -42,6 +42,10 @@ module.exports =
       type: 'boolean'
       default: true
       description: 'Try to be "smart" when inserting operators (see README)'
+    clearRStudioConsole:
+      type: 'boolean'
+      default: false
+      description: 'When sending to RStudio, first clear the console'
 
   subscriptions: null
 
@@ -503,6 +507,10 @@ module.exports =
       command.push 'tell application "RStudio" to activate'
     command.push 'tell application "RStudio" to cmd code'
     command = command.join('\n')
+
+    clearRStudioConsole = atom.config.get 'r-exec.clearRStudioConsole'
+    if clearRStudioConsole
+      selection = 'cat("\\f")\n'.addSlashes() + selection
 
     osascript.execute command, {code: selection},
       (error, result, raw) ->


### PR DESCRIPTION
When running and iterating on large chunks of code, I find it nice to clear the console each time before it runs so the code I previously ran isn't distracting. In RStudio, this can be done with `ctrl+L`, or the command `cat("\f")`. This new option prepends that command to any code that is sent to RStudio, so that the console is cleared each time.

It should also be possible to make this more generic so the consoles can be cleared on other targets as well, instead of just RStudio.