### PR TITLE
Override default keybinding for cmd-enter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,6 @@ Search for `r-exec` within package search in the Settings View.
 
 ## Configuration
 
-### Keybindings
-
-While `cmd-enter` is bound to sending code in the package, it is also annoyingly bound to entering a new line by default in atom.
-In order to make it work, you must add the following binding in `~/.atom/keymap.cson`:
-
-```javascript
-'atom-workspace atom-text-editor:not([mini])':
-  'cmd-enter': 'r-exec:send-command'
-```
-
 ### Behavior
 
 All configuration can be done in the settings panel. Alternatively, you can edit your configuration file as noted below.

--- a/keymaps/r-exec.cson
+++ b/keymaps/r-exec.cson
@@ -6,12 +6,13 @@
 # the root workspace element.
 
 # For more detailed documentation see
-# https://atom.io/docs/latest/advanced/keymaps
+# http://flight-manual.atom.io/behind-atom/sections/keymaps-in-depth/
 
 # eventually make it like R-box with cmd-enter
 # and have custom command palette to choose application
 # https://discuss.atom.io/t/custom-use-of-the-command-palette/15702/2
-'atom-text-editor':
+# ---------- Editor --------------
+'atom-text-editor[data-grammar="source r"]:not([mini])':
   'shift-cmd-e': 'r-exec:setwd'
   'cmd-enter': 'r-exec:send-command'
   'shift-cmd-u': 'r-exec:send-function'
@@ -21,3 +22,7 @@
   'shift-alt-m': 'r-exec:insert-pipe'
   'shift-alt-p': 'r-exec:send-previous-command'
   # shift-cmd y, u, i, j, k, x, m
+
+# Override cmd-enter
+'.platform-darwin atom-text-editor[data-grammar="source r"]:not([mini])':
+  'cmd-enter': 'r-exec:send-command'


### PR DESCRIPTION
I thought it was weird that you'd need to manually add something to your keymap.cson to use `cmd-enter`, because I use the [Hydrogen](https://atom.io/packages/hydrogen) package often and I never had to edit the keymap to use `cmd-enter` with that package. 

Looking at Hydrogen's keymap.cson, the included changes should force the use of `cmd-enter` for this package. I've also added `[data-grammar="source r"]` because it's likely anyone using this package would only be using it for files covered by the R grammar file, but you could take that out if you want.

I believe this could fix https://github.com/pimentel/atom-r-exec/issues/52 and https://github.com/pimentel/atom-r-exec/issues/51.